### PR TITLE
Add usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ results.join(', ');// 'before: foo, base: bar, after: foo'
 
 Redefine the `obj.method`  which around `obj.method` by `fn`.
 
+## Tests
+
+```sh
+npm test
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Simple AOP library for both Node.js and browsers.
 
+- [Aspect-oriented programming - Wikipedia](http://en.wikipedia.org/wiki/Aspect-oriented_programming "Aspect-oriented programming - Wikipedia, the free encyclopedia")
+
 ```js
 function base() {}
 
@@ -39,17 +41,54 @@ $ bower install advice
 
 ## Documentation
 
-### advice.before(base, fn)
+### advice.before(base, fn) : function
 
-### advice.before(obj, method, fn)
+Return compose a new function which calls a `fn` before `base` returns.
 
-### advice.after(base, fn)
+Order: `fn` -> `base`
 
-### advice.after(obj, method, fn)
+### advice.before(obj, method, fn) : void
 
-### advice.around(base, fn)
+Redefine the `obj.method` which will be called a `fn` before the original `obj.method` is called.
 
-### advice.around(obj, method, fn)
+Order: `fn` -> `obj.method`
+
+### advice.after(base, fn) : function
+
+Return compose a new function which calls a `fn` after `base` returns.
+
+Order: `base` -> `fn`
+
+### advice.after(obj, method, fn) : void
+
+Redefine the `obj.method`  which will be called a `fn` before `obj.method` is called.
+
+Order: `obj.method` ->  `fn`
+
+### advice.around(base, fn) : function
+
+Return compose a new function which around the `base` by `fn`.
+
+```js
+function base() {}
+var results = [];
+var fn = advice.around(base, function(base, value) {
+  var result = 'around: ' + value;
+  // before
+  results.push('before: ' + value);
+  // base
+  base('base was called');
+  // after 
+  results.push('after: ' + value);
+  return result;
+});
+fn('foo'); // 'around: foo'
+results.join(', ');// 'before: foo, base: bar, after: foo'
+```
+
+### advice.around(obj, method, fn) : void
+
+Redefine the `obj.method`  which around `obj.method` by `fn`.
 
 ## License
 


### PR DESCRIPTION
This pull request includes these documentation updated:
- Add link to [Aspect-oriented programming - Wikipedia, the free encyclopedia](http://en.wikipedia.org/wiki/Aspect-oriented_programming)
- Add Usage
- Add Tests section

[dojo/aspect](http://dojotoolkit.org/reference-guide/1.10/dojo/aspect.html) used as a reference.
