### PR TITLE
return composed fn instead of altering methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ var obj = {
   foo: function() {}
 };
 
-// redefine a method which calls a function after obj.foo returns
-advice.after(obj, 'foo', function() {
+// compose a new function which calls a function after obj.foo returns
+var fn = advice.after(obj, 'foo', function() {
   console.log('obj.foo was called');
 });
 ```
@@ -47,9 +47,9 @@ Return compose a new function which calls a `fn` before `base` returns.
 
 Order: `fn` -> `base`
 
-### advice.before(obj, method, fn) : void
+### advice.before(obj, method, fn) : function
 
-Redefine the `obj.method` which will be called a `fn` before the original `obj.method` is called.
+Return compose a new function which will call an `fn` before the original `obj.method` is called.
 
 Order: `fn` -> `obj.method`
 
@@ -59,15 +59,15 @@ Return compose a new function which calls a `fn` after `base` returns.
 
 Order: `base` -> `fn`
 
-### advice.after(obj, method, fn) : void
+### advice.after(obj, method, fn) : function
 
-Redefine the `obj.method`  which will be called a `fn` before `obj.method` is called.
+Return compose a new function which will call an `fn` after the original `obj.method` is called.
 
 Order: `obj.method` ->  `fn`
 
 ### advice.around(base, fn) : function
 
-Return compose a new function which around the `base` by `fn`.
+Return compose a new function which will be called around the `base` by `fn`.
 
 ```js
 function base() {}
@@ -86,9 +86,10 @@ fn('foo'); // 'around: foo'
 results.join(', ');// 'before: foo, base: bar, after: foo'
 ```
 
-### advice.around(obj, method, fn) : void
+### advice.around(obj, method, fn) : function
 
-Redefine the `obj.method`  which around `obj.method` by `fn`.
+Return compose a new function which will be called around the `obj.method` by `fn`.
+
 
 ## Tests
 

--- a/advice.js
+++ b/advice.js
@@ -3,6 +3,13 @@
 
 var slice = Array.prototype.slice;
 
+var bind = Function.prototype.bind || function (context, fn) {
+  return function () {
+    var args = slice.call(arguments);
+    return fn.apply(context, args);
+  }
+};
+
 function before(base, fn) {
   return function() {
     var args = slice.call(arguments);
@@ -33,7 +40,7 @@ function create(advice) {
     if ('function' === typeof name) {
       return advice(context, name);
     } else {
-      context[name] = advice(context[name], fn);
+      return advice(bind(context, context[name]), bind(context, fn));
     }
   };
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "advice",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Simple AOP module",
   "main": "advice.js",
   "keywords": [

--- a/index.js
+++ b/index.js
@@ -2,6 +2,13 @@
 
 var slice = Array.prototype.slice;
 
+var bind = Function.prototype.bind || function (context, fn) {
+  return function () {
+    var args = slice.call(arguments);
+    return fn.apply(context, args);
+  }
+};
+
 function before(base, fn) {
   return function() {
     var args = slice.call(arguments);
@@ -32,7 +39,7 @@ function create(advice) {
     if ('function' === typeof name) {
       return advice(context, name);
     } else {
-      context[name] = advice(context[name], fn);
+      return advice(bind(context, context[name]), bind(context, fn));
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advice.js",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Simple AOP module",
   "scripts": {
     "prepublish": "npm run build",

--- a/test/adviceSpec.js
+++ b/test/adviceSpec.js
@@ -69,33 +69,33 @@ describe('advice', function() {
 
     describe('before', function() {
       it('should compose a new method which executes the "before" function before the base one', function() {
-        advice.before(subject, 'base', function(value) {
+        var fn = advice.before(subject, 'base', function(value) {
           var result = 'before: ' + value;
           this.results.push(result);
           return result;
         });
 
-        expect(subject.base('foo')).toEqual('base: foo');
+        expect(fn('foo')).toEqual('base: foo');
         expect(subject.results.join(', ')).toEqual('before: foo, base: foo');
       });
     });
 
     describe('after', function () {
       it('should compose a new method which executes the "before" function before the base one', function() {
-        advice.after(subject, 'base', function(value) {
+        var fn = advice.after(subject, 'base', function(value) {
           var result = 'after: ' + value;
           this.results.push(result);
           return result;
         });
 
-        expect(subject.base('foo')).toEqual('base: foo');
+        expect(fn('foo')).toEqual('base: foo');
         expect(subject.results.join(', ')).toEqual('base: foo, after: foo');
       });
     });
 
     describe('around', function () {
       it('should compose a new method which executes the "around" function with base one in the first argument', function() {
-        advice.around(subject, 'base', function(base, value) {
+        var fn = advice.around(subject, 'base', function(base, value) {
           var result = 'around: ' + value;
           this.results.push('before: ' + value);
           base.call(this, 'bar');
@@ -103,7 +103,7 @@ describe('advice', function() {
           return result;
         });
 
-        expect(subject.base('foo')).toEqual('around: foo');
+        expect(fn('foo')).toEqual('around: foo');
         expect(subject.results.join(', ')).toEqual('before: foo, base: bar, after: foo');
       });
     });


### PR DESCRIPTION
It's beneficial to not alter the original method and instead return the composed method. This way the original can be used at a later time.
